### PR TITLE
Allow environment variable NEMS_MACHINE to overwrite (or set) MACHINE_ID

### DIFF
--- a/tests/detect_machine.sh
+++ b/tests/detect_machine.sh
@@ -122,6 +122,9 @@ case $(hostname -f) in
   login4.stampede2.tacc.utexas.edu) MACHINE_ID=stampede ;; ### stampede4
 esac
 
+# Overwrite auto-detect with NEMS_MACHINE if set
+MACHINE_ID=${NEMS_MACHINE:-${MACHINE_ID}}
+
 # For Theia and Cheyenne, append compiler
 if [ $MACHINE_ID = theia ] || [ $MACHINE_ID = hera ] || [ $MACHINE_ID = cheyenne ] || [ $MACHINE_ID = jet ] || [ $MACHINE_ID = gaea ] || [ $MACHINE_ID = stampede ] ; then
     MACHINE_ID=${MACHINE_ID}.${COMPILER}


### PR DESCRIPTION
Using the same logic as for `NEMS_COMPILER` to set the compiler to use, the environment variable `NEMS_MACHINE` can be used to overwrite (or set, if the logic in detect_machine.sh fails) the `MACHINE_ID` in the `rt.sh` regression testing system.

This PR is only for the `rt.sh` based regression testing, not for `NEMSCompsetRun`.
