### PR TITLE
dtc/develop: turn off WW3 tests in rt_ccpp_dtc.conf for platforms other than hera.intel

### DIFF
--- a/tests/rt_ccpp_dtc.conf
+++ b/tests/rt_ccpp_dtc.conf
@@ -35,13 +35,8 @@ RUN     | fv3_csawmg3shoc127                                                    
 RUN     | fv3_csawmg3shoc127                                                                                    | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_csawmg3shoc127                                                                                    | standard    | jet.intel      | fv3         |
 # Coupled with WW3
-COMPILE | REPRO=Y WW3=Y                                                                                         | standard    | gaea.intel     | fv3         |
 COMPILE | REPRO=Y WW3=Y                                                                                         | standard    | hera.intel     | fv3         |
-COMPILE | REPRO=Y WW3=Y                                                                                         | standard    | cheyenne.intel | fv3         |
-COMPILE | REPRO=Y WW3=Y                                                                                         | standard    | cheyenne.gnu   | fv3         |
-COMPILE | REPRO=Y WW3=Y                                                                                         | standard    | stampede.intel | fv3         |
-COMPILE | REPRO=Y WW3=Y                                                                                         | standard    | jet.intel      | fv3         |
-RUN     | fv3_gfdlmprad                                                                                         | standard    |                | fv3         |
+RUN     | fv3_gfdlmprad                                                                                         | standard    | hera.intel     | fv3         |
 # 32-bit dynamics
 COMPILE | REPRO=Y 32BIT=Y                                                                                       | standard    | gaea.intel     | fv3         |
 COMPILE | REPRO=Y 32BIT=Y                                                                                       | standard    | hera.intel     | fv3         |
@@ -110,13 +105,8 @@ RUN     | fv3_ccpp_gfdlmp                                                       
 RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                | standard    |                |             |
 RUN     | fv3_ccpp_gfdlmprad_noahmp                                                                             | standard    |                |             |
 # Coupled with WW3
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp WW3=Y                                              | standard    | gaea.intel     |             |
 COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp WW3=Y                                              | standard    | hera.intel     |             |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp WW3=Y                                              | standard    | cheyenne.intel |             |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp WW3=Y                                              | standard    | cheyenne.gnu   |             |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp WW3=Y                                              | standard    | stampede.intel |             |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp WW3=Y                                              | standard    | jet.intel      |             |
-RUN     | fv3_ccpp_gfdlmprad                                                                                    | standard    |                |             |
+RUN     | fv3_ccpp_gfdlmprad                                                                                    | standard    | hera.intel     |             |
 ## csawmg-based tests (Intel only, crashing with GNU and PGI)
 #COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc                                                | standard    | gaea.intel     |             |
 #COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc                                                | standard    | hera.intel     |             |
@@ -212,13 +202,8 @@ RUN     | fv3_ccpp_satmedmfq                                                    
 RUN     | fv3_ccpp_lheatstrg                                                                                    | standard    |                |             |
 RUN     | fv3_ccpp_h2ophys                                                                                      | standard    |                |             |
 # Coupled with WW3
-COMPILE | CCPP=Y REPRO=Y WW3=Y                                                                                  | standard    | gaea.intel     |             |
 COMPILE | CCPP=Y REPRO=Y WW3=Y                                                                                  | standard    | hera.intel     |             |
-COMPILE | CCPP=Y REPRO=Y WW3=Y                                                                                  | standard    | cheyenne.intel |             |
-COMPILE | CCPP=Y REPRO=Y WW3=Y                                                                                  | standard    | cheyenne.gnu   |             |
-COMPILE | CCPP=Y REPRO=Y WW3=Y                                                                                  | standard    | stampede.intel |             |
-COMPILE | CCPP=Y REPRO=Y WW3=Y                                                                                  | standard    | jet.intel      |             |
-RUN     | fv3_ccpp_gfdlmprad                                                                                    | standard    |                |             |
+RUN     | fv3_ccpp_gfdlmprad                                                                                    | standard    | hera.intel     |             |
 ## Note: any suite that uses csawmg crashes with GNU and PGI (--> there must be something wrong with it)
 #RUN     | fv3_ccpp_csawmgshoc                                                                                   | standard    | gaea.intel     |             |
 #RUN     | fv3_ccpp_csawmgshoc                                                                                   | standard    | hera.intel     |             |


### PR DESCRIPTION
Update of tests/rt_ccpp_dtc.conf: WW3 only supported on hera (hera.intel). No testing required, can be merged anytime.