### PR TITLE
Revert PBS queue change on Cheyenne

### DIFF
--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -271,7 +271,7 @@ elif [[ $MACHINE_ID = cheyenne.* ]]; then
 
   export PYTHONPATH=
   ECFLOW_START=
-  QUEUE=economy
+  QUEUE=premium
   PARTITION=
   dprefix=/glade/scratch
   DISKNM=/glade/p/ral/jntp/GMTB/NEMSfv3gfs/RT


### PR DESCRIPTION
Revert recent change pf PBS queue on Cheyenne (from premium to economy, i.e. going back to premium). With the long wait times in the economy queue, the automatic regression test scripts (launched by cron) are killed by the system for `rt_intel.conf`. Will merge immediately.