### PR TITLE
dtc/develop: update rt_intel.conf (for Cheyenne only)

### DIFF
--- a/tests/rt_intel.conf
+++ b/tests/rt_intel.conf
@@ -99,8 +99,6 @@ RUN     | fv3_regional_quilt                                                    
 # for surface pressure, out of range warnings and all other sorts of errors
 #RUN     | fv3_regional_c768                                                                                                              | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_gfdlmp_32bit                                                                                                               | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_gfs_v15                                                                                                                    | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_gfs_v15plus                                                                                                                | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_cpt                                                                                                                        | standard    | cheyenne.intel | fv3         |
 
 #######################################################################################################################################################################################
@@ -153,12 +151,10 @@ COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_cs
 RUN     | fv3_ccpp_csawmg                                                                                                                | standard    | cheyenne.intel |             |
 RUN     | fv3_ccpp_satmedmf                                                                                                              | standard    | cheyenne.intel |             |
 
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_v15,FV3_GFS_v15plus,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                   | standard    | cheyenne.intel | fv3         |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                                               | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfdlmp_32bit                                                                                                          | standard    | cheyenne.intel |             |
 # inline post not yet working on Cheyenne
 #RUN     | fv3_ccpp_gfdlmprad_32bit_post                                                                                                  | standard    | cheyenne.intel |             |
-RUN     | fv3_ccpp_gfs_v15                                                                                                               | standard    | cheyenne.intel |             |
-RUN     | fv3_ccpp_gfs_v15plus                                                                                                           | standard    | cheyenne.intel |             |
 RUN     | fv3_ccpp_cpt                                                                                                                   | standard    | cheyenne.intel |             |
 RUN     | fv3_ccpp_gsd                                                                                                                   | standard    | cheyenne.intel | fv3         |
 
@@ -216,23 +212,41 @@ COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3
 RUN     | fv3_ccpp_csawmg                                                                                                                | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_satmedmf                                                                                                              | standard    | cheyenne.intel | fv3         |
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_v15,FV3_GFS_v15plus,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                           | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                                                       | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfdlmp_32bit                                                                                                          | standard    | cheyenne.intel | fv3         |
 # inline post not yet working on Cheyenne
 #RUN     | fv3_ccpp_gfdlmprad_32bit_post                                                                                                  | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_gfs_v15                                                                                                               | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_gfs_v15plus                                                                                                           | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_cpt                                                                                                                   | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gsd                                                                                                                   | standard    | cheyenne.intel | fv3         |
 
+#######################################################################################################################################################################################
+# New tests for current operational (v15p2) and next candidate (v16beta) EMC suites                                                                                                   #
+#######################################################################################################################################################################################
+
+# CCPP PROD tests                                                                                                                                                                     #
+
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta                                                                           | standard    | cheyenne.intel | fv3         |
+
 RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
 
-#######################################################################################################################################################################################
-# CCPP DEBUG tests                                                                                                                                                                     #
-#######################################################################################################################################################################################
+# CCPP DEBUG tests                                                                                                                                                                 #
 
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta DEBUG=Y                                                                   | standard    | cheyenne.intel | fv3         |
+
 RUN     | fv3_ccpp_gfs_v15p2_debug                                                                                                       | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta_debug                                                                                                     | standard    | cheyenne.intel | fv3         |
+
+# CCPP REPRO tests                                                                                                                                                                #
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta REPRO=Y                                                                   | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
+
+# IPD REPRO tests (verify against CCPP REPRO tests)                                                                                                                               #
+
+COMPILE | REPRO=Y                                                                                                                        | standard    | cheyenne.intel |             |
+
+RUN     | fv3_gfs_v15p2                                                                                                                  | standard    | cheyenne.intel |             |
+RUN     | fv3_gfs_v16beta                                                                                                                | standard    | cheyenne.intel |             |


### PR DESCRIPTION
This PR updates `tests/rt_intel.conf` (used by Cheyenne only) to reflect the removal of the GFSv15 and GFSv15plus regression tests in the last update from EMC.

Regression test baselines were created for both Intel and GNU on Cheyenne (using `rt_intel.conf` and `rt_gnu.conf`), copied to the official baseline directory, and verified against. All tests pass.

I will merge this PR without approval, since there are no code changes and since all the tests passed.

[rt_gnu_create.log](https://github.com/NCAR/ufs-weather-model/files/4232191/rt_gnu_create.log)
[rt_gnu_verify.log](https://github.com/NCAR/ufs-weather-model/files/4232192/rt_gnu_verify.log)
[rt_intel_create.log](https://github.com/NCAR/ufs-weather-model/files/4232193/rt_intel_create.log)
[rt_intel_verify.log](https://github.com/NCAR/ufs-weather-model/files/4232194/rt_intel_verify.log)
