### PR TITLE
Update GNU compiler on Cheyenne to version 9.1.0

### DIFF
--- a/modulefiles/cheyenne.gnu/fv3
+++ b/modulefiles/cheyenne.gnu/fv3
@@ -16,12 +16,12 @@ module-whatis "loads NEMS FV3 prerequisites for Cheyenne/GNU"
 ## this typically includes compiler, MPI and job scheduler
 ##
 module load ncarenv/1.3
-module load gnu/8.3.0
+module load gnu/9.1.0
 module load mpt/2.19
 module load ncarcompilers/0.5.0
-module load netcdf/4.6.3
+module load netcdf/4.7.3
 
-module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/gnu-8.3.0/mpt-2.19
+module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/gnu-9.1.0/mpt-2.19
 
 ##
 ## use pre-compiled EMSF library for above compiler / MPI combination


### PR DESCRIPTION
This PR updates the GNU compiler used on Cheyenne to version 9.1.0. This has become necessary because of the recent merge of the RRTMGP code into dtc/develop.

The RRTMGP code uses a Fortran 2008 intrinsic called FINDLOC, which the previous version of the GNU compiler on Cheyenne (8.3.0) does not recognize. Both the ccpp-framework as well as the UFS requirements explicitly allow the Fortran 2008 standard.

I compiled the same version of NCEPLIBS that was used with GNU 8.3.0 (not yet the public release version, but the previous NCAR version), sionlib-1.7.4 and ESMF 8.0.0 with GNU 9.1.0 and created the modulefiles. Then, a new baseline was created using `rt_gnu.conf` and copied to the existing regression test directory (with the date tag corresponding to the RRTMGP PR). The same `rt_gnu.conf` was used afterwards to verify against this new baseline. This PR is ready to merge.

[rt_cheyenne_gnu_create.log](https://github.com/NCAR/ufs-weather-model/files/4403292/rt_cheyenne_gnu_create.log)
[rt_cheyenne_gnu.log](https://github.com/NCAR/ufs-weather-model/files/4403293/rt_cheyenne_gnu.log)
