### PR TITLE
dtc/hwrf-physics: HWRF Ferrier-Aligo MP scheme updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NCAR/fv3atm
-	#branch = dtc/hwrf-physics
-	url = https://github.com/climbfuji/fv3atm
-	branch = HAFS_fer_hires_for_dtc_hwrf-physics
+	url = https://github.com/NCAR/fv3atm
+	branch = dtc/hwrf-physics
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NCAR/fv3atm
-	branch = dtc/hwrf-physics
+	#url = https://github.com/NCAR/fv3atm
+	#branch = dtc/hwrf-physics
+	url = https://github.com/climbfuji/fv3atm
+	branch = HAFS_fer_hires_for_dtc_hwrf-physics
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -253,7 +253,7 @@ RUN     | fv3_ccpp_gfdlmprad_32bit_post                                         
 RUN     | fv3_ccpp_cpt                                                                                                                   | standard    |                |             |
 RUN     | fv3_ccpp_gsd                                                                                                                   | standard    |                | fv3         |
 
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires_update_moist,FV3_HAFS_FA_HWRF_RRTMG                                           | standard    | hera.intel     | fv3         |
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                        | standard    | hera.intel     | fv3         |
 
 RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | hera.intel     | fv3         |
@@ -377,7 +377,7 @@ RUN     | fv3_ccpp_gsd                                                          
 RUN     | fv3_ccpp_thompson                                                                                                              | standard    |                | fv3         |
 RUN     | fv3_ccpp_thompson_no_aero                                                                                                      | standard    |                | fv3         |
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires_update_moist,FV3_HAFS_FA_HWRF_RRTMG                                                   | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                                | standard    | hera.intel     | fv3         |
 
 RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | hera.intel     | fv3         |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -255,7 +255,7 @@ RUN     | fv3_ccpp_gsd                                                          
 
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires_update_moist,FV3_HAFS_FA_HWRF_RRTMG                                           | standard    | hera.intel     | fv3         |
 
-RUN     | fv3_ccpp_regional_c768_FA_update_moist                                                                                         | standard    | hera.intel     | fv3         |
+RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | hera.intel     | fv3         |
 
@@ -379,7 +379,7 @@ RUN     | fv3_ccpp_thompson_no_aero                                             
 
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires_update_moist,FV3_HAFS_FA_HWRF_RRTMG                                                   | standard    | hera.intel     | fv3         |
 
-RUN     | fv3_ccpp_regional_c768_FA_update_moist                                                                                         | standard    | hera.intel     | fv3         |
+RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | hera.intel     | fv3         |
 

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -383,11 +383,11 @@ done
 
 # Fix me - make those definitions and DISKNM consistent
 if [[ $MACHINE_ID = hera.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200410/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200415/${COMPILER^^}}
 elif [[ $MACHINE_ID = cheyenne.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/hwrf-physics-20200410/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/hwrf-physics-20200415/${COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200410}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200415}
 fi
 
 shift $((OPTIND-1))

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -22,11 +22,12 @@ RUN     | fv3_gfdlmp                                                            
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp                                                                             | standard    |                |             |
 RUN     | fv3_ccpp_gfdlmp                                                                                                                | standard    | cheyenne.gnu   |             |
 
-COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                        | standard    |                | fv3         |
-
-RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.gnu   | fv3         |
-RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.gnu   | fv3         |
-RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.gnu   | fv3         |
+# Turn off for now - either running too long or crashing with GNU 9.1.0 on Cheyenne
+#COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                        | standard    |                | fv3         |
+#
+#RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.gnu   | fv3         |
+#RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.gnu   | fv3         |
+#RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.gnu   | fv3         |
 
 #######################################################################################################################################################################################
 # CCPP PROD tests                                                                                                                                                                     #
@@ -43,11 +44,12 @@ COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta                  
 RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.gnu   | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.gnu   | fv3         |
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                                | standard    |                | fv3         |
-
-RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.gnu   | fv3         |
-RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.gnu   | fv3         |
-RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.gnu   | fv3         |
+# Turn off for now - either running too long or crashing with GNU 9.1.0 on Cheyenne
+#COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                                | standard    |                | fv3         |
+#
+#RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.gnu   | fv3         |
+#RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.gnu   | fv3         |
+#RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.gnu   | fv3         |
 
 #######################################################################################################################################################################################
 # CCPP DEBUG tests                                                                                                                                                                     #

--- a/tests/rt_gnu.conf
+++ b/tests/rt_gnu.conf
@@ -22,6 +22,12 @@ RUN     | fv3_gfdlmp                                                            
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp                                                                             | standard    |                |             |
 RUN     | fv3_ccpp_gfdlmp                                                                                                                | standard    | cheyenne.gnu   |             |
 
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                        | standard    |                | fv3         |
+
+RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.gnu   | fv3         |
+RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.gnu   | fv3         |
+RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.gnu   | fv3         |
+
 #######################################################################################################################################################################################
 # CCPP PROD tests                                                                                                                                                                     #
 #######################################################################################################################################################################################
@@ -36,6 +42,12 @@ COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta                  
 
 RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.gnu   | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.gnu   | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                                | standard    |                | fv3         |
+
+RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.gnu   | fv3         |
+RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.gnu   | fv3         |
+RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.gnu   | fv3         |
 
 #######################################################################################################################################################################################
 # CCPP DEBUG tests                                                                                                                                                                     #

--- a/tests/rt_intel.conf
+++ b/tests/rt_intel.conf
@@ -65,21 +65,14 @@ RUN     | fv3_ccpp_regional_c768_FA                                             
 RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.intel | fv3         |
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP                                                       | standard    | cheyenne.intel | fv3         |
-
-RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_rrtmgp                                                                                                                | standard    | cheyenne.intel | fv3         |
-
 #######################################################################################################################################################################################
 # CCPP DEBUG tests                                                                                                                                                                     #
 #######################################################################################################################################################################################
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y                                               | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta DEBUG=Y                                                                   | standard    | cheyenne.intel | fv3         |
 
 RUN     | fv3_ccpp_gfs_v15p2_debug                                                                                                       | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta_debug                                                                                                     | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_rrtmgp_debug                                                                                                          | standard    | cheyenne.intel | fv3         |
 
 COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y                                                         | standard    | cheyenne.intel | fv3         |
 
@@ -91,11 +84,10 @@ RUN     | fv3_ccpp_thompson_no_aero_debug                                       
 # CCPP REPRO tests                                                                                                                                                                    #
 #######################################################################################################################################################################################
 
-COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP REPRO=Y                                               | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta REPRO=Y                                                                   | standard    | cheyenne.intel | fv3         |
 
 RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
 RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
-RUN     | fv3_ccpp_rrtmgp                                                                                                                | standard    | cheyenne.intel | fv3         |
 
 COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                        | standard    | cheyenne.intel | fv3         |
 

--- a/tests/rt_intel.conf
+++ b/tests/rt_intel.conf
@@ -1,0 +1,104 @@
+#######################################################################################################################################################################################
+# CCPP PROD tests                                                                                                                                                                     #
+#######################################################################################################################################################################################
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017                                                                                            | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_control                                                                                                               | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_decomp                                                                                                                | standard    | cheyenne.intel |             |
+RUN     | fv3_ccpp_2threads                                                                                                              | standard    | cheyenne.intel |             |
+RUN     | fv3_ccpp_restart                                                                                                               | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_read_inc                                                                                                              | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_wrtGauss_netcdf_esmf                                                                                                  | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_wrtGauss_netcdf                                                                                                       | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_wrtGauss_nemsio                                                                                                       | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_wrtGauss_nemsio_c192                                                                                                  | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_stochy                                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_iau                                                                                                                   | standard    | cheyenne.intel | fv3         |
+
+# WW3 not yet working on Cheyenne
+#COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_gfdlmp WW3=Y                                                                  | standard    | cheyenne.intel | fv3         |
+#RUN     | fv3_ccpp_gfdlmprad                                                                                                             | standard    | cheyenne.intel | fv3         |
+#RUN     | fv3_ccpp_wrtGauss_nemsio_c768                                                                                                  | standard    | cheyenne.intel | fv3         |
+
+# Run one test using the NEMSAppBuilder, to ensure we don't break it:
+APPBUILD| CCPP                                                                                                                           | standard    | cheyenne.intel |             |
+RUN     | fv3_ccpp_appbuild                                                                                                              | standard    | cheyenne.intel |             |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y                                                             | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_control_32bit                                                                                                         | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_stretched                                                                                                             | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_stretched_nest                                                                                                        | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp_regional,FV3_GFS_2017_gfdlmp_regional_c768 32BIT=Y                                  | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_control                                                                                                      | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_restart                                                                                                      | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_quilt                                                                                                        | standard    | cheyenne.intel | fv3         |
+# fv3_regional_c768 not working on Cheyenne, code aborts with invalid values
+# for surface pressure, out of range warnings and all other sorts of errors
+#RUN     | fv3_ccpp_regional_c768                                                                                                         | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017,FV3_GFS_2017_stretched 32BIT=Y DEBUG=Y                                                     | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_control_debug                                                                                                         | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_stretched_nest_debug                                                                                                  | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp                                                          | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfdlmp                                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                                         | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfdlmprad_noahmp                                                                                                      | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_csawmgshoc,FV3_GFS_2017_csawmg,FV3_GFS_2017_satmedmf                                       | standard    | cheyenne.intel | fv3         |
+#RUN     | fv3_ccpp_csawmgshoc                                                                                                            | standard    | cheyenne.intel | fv3         |
+#RUN     | fv3_ccpp_csawmg3shoc127                                                                                                        | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_csawmg                                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_satmedmf                                                                                                              | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_CPT_v0,FV3_GSD_v0 32BIT=Y                                                       | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfdlmp_32bit                                                                                                          | standard    | cheyenne.intel | fv3         |
+# inline post not yet working on Cheyenne
+#RUN     | fv3_ccpp_gfdlmprad_32bit_post                                                                                                  | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_cpt                                                                                                                   | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gsd                                                                                                                   | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                                | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP                                                       | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_rrtmgp                                                                                                                | standard    | cheyenne.intel | fv3         |
+
+#######################################################################################################################################################################################
+# CCPP DEBUG tests                                                                                                                                                                     #
+#######################################################################################################################################################################################
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP DEBUG=Y                                               | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_gfs_v15p2_debug                                                                                                       | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v16beta_debug                                                                                                     | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_rrtmgp_debug                                                                                                          | standard    | cheyenne.intel | fv3         |
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson 32BIT=Y DEBUG=Y                                                         | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_gsd_debug                                                                                                             | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_thompson_debug                                                                                                        | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_thompson_no_aero_debug                                                                                                | standard    | cheyenne.intel | fv3         |
+
+#######################################################################################################################################################################################
+# CCPP REPRO tests                                                                                                                                                                    #
+#######################################################################################################################################################################################
+
+COMPILE | CCPP=Y STATIC=Y SUITES=FV3_GFS_v15p2,FV3_GFS_v16beta,FV3_GFS_2017_RRTMGP REPRO=Y                                               | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_gfs_v15p2                                                                                                             | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_gfs_v16beta                                                                                                           | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_rrtmgp                                                                                                                | standard    | cheyenne.intel | fv3         |
+
+COMPILE | REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_HAFS_ferhires,FV3_HAFS_FA_HWRF_RRTMG                                                        | standard    | cheyenne.intel | fv3         |
+
+RUN     | fv3_ccpp_regional_c768_FA                                                                                                      | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_c768_HWRF_PBL                                                                                                | standard    | cheyenne.intel | fv3         |
+RUN     | fv3_ccpp_regional_c768_FA_HWRF_RRTMG                                                                                           | standard    | cheyenne.intel | fv3         |

--- a/tests/tests/fv3_ccpp_regional_c768_FA
+++ b/tests/tests/fv3_ccpp_regional_c768_FA
@@ -20,7 +20,7 @@ export WLCLK=30
 export RUN_SCRIPT=rt_fv3.sh
 export FV3_RUN=ccpp_regional_FA_run.IN
 
-export CCPP_SUITE=FV3_HAFS_ferhires_update_moist
+export CCPP_SUITE=FV3_HAFS_ferhires
 export CCPP_LIB_DIR=ccpp/lib
 export INPUT_NML=ccpp_regional_c768_FA.nml.IN
 export LRADAR=.T.

--- a/tests/tests/fv3_ccpp_regional_c768_HWRF_PBL
+++ b/tests/tests/fv3_ccpp_regional_c768_HWRF_PBL
@@ -20,7 +20,7 @@ export WLCLK=30
 export RUN_SCRIPT=rt_fv3.sh
 export FV3_RUN=ccpp_regional_FA_run.IN
 
-export CCPP_SUITE=FV3_HAFS_ferhires_update_moist
+export CCPP_SUITE=FV3_HAFS_ferhires
 export CCPP_LIB_DIR=ccpp/lib
 export INPUT_NML=ccpp_regional_c768_FA.nml.IN
 export LRADAR=.T.


### PR DESCRIPTION
This PR replaces https://github.com/NCAR/ufs-weather-model/pull/25, which was for target branch dtc/develop. Only one commit was required and cherry-picked from this PR, namely https://github.com/NCAR/ufs-weather-model/commit/fa355b9a4fccb603e5142c939309f10fba84ae34. Additional updates are made to tests/rt.conf to reflect the change of the regression test name from this commit.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/435
https://github.com/NCAR/fv3atm/pull/43
https://github.com/NCAR/ufs-weather-model/pull/41

For regression testing information, see below.