### PR TITLE
Bug fix in FA, HWRF RRTMG and HWRF SAS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NCAR/fv3atm
-	branch = dtc/hwrf-physics
+	#url = https://github.com/NCAR/fv3atm
+	#branch = dtc/hwrf-physics
+	url = https://github.com/climbfuji/fv3atm
+	branch = dtc-hwrf-physics-man-bugfix-fa
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NCAR/fv3atm
-	#branch = dtc/hwrf-physics
-	url = https://github.com/climbfuji/fv3atm
-	branch = dtc-hwrf-physics-man-bugfix-fa
+	url = https://github.com/NCAR/fv3atm
+	branch = dtc/hwrf-physics
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -383,11 +383,11 @@ done
 
 # Fix me - make those definitions and DISKNM consistent
 if [[ $MACHINE_ID = hera.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200415/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200504/${COMPILER^^}}
 elif [[ $MACHINE_ID = cheyenne.* ]]; then
-  RTPWD=${RTPWD:-$DISKNM/hwrf-physics-20200415/${COMPILER^^}}
+  RTPWD=${RTPWD:-$DISKNM/hwrf-physics-20200504/${COMPILER^^}}
 else
-  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200415}
+  RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/hwrf-physics-20200504}
 fi
 
 shift $((OPTIND-1))


### PR DESCRIPTION
Update submodule pointer for fv3atm and date tag for regression test baseline in `tests/rt.sh`. See description in https://github.com/NCAR/ccpp-physics/pull/447.

Associated PRs:

https://github.com/NCAR/ccpp-physics/pull/447
https://github.com/NCAR/fv3atm/pull/47
https://github.com/NCAR/ufs-weather-model/pull/45

For regression testing information, see below.