### PR TITLE
dtc/hwrf-physics: hera/jet module environment update

### DIFF
--- a/modulefiles/hera.gnu/fv3
+++ b/modulefiles/hera.gnu/fv3
@@ -15,7 +15,8 @@ setenv NCEPLIBS /scratch2/NCEPDEV/nwprod/NCEPLIBS
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 ##
 ## load programming environment

--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -15,7 +15,8 @@ setenv NCEPLIBS /scratch2/NCEPDEV/nwprod/NCEPLIBS
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 ##
 ## load programming environment

--- a/modulefiles/jet.intel/fv3
+++ b/modulefiles/jet.intel/fv3
@@ -13,7 +13,8 @@ module purge
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 module load intel/18.0.5.274
 module load impi/2018.4.274


### PR DESCRIPTION
The way the contrib module is loaded on jet and hera changes on 06/11/2020, the previous commands do no longer work and building the model fails.

This PR cherry-picks the fully tested changes from ufs-community's ufs-weather-model develop branch and can be merged without testing.