### PR TITLE
Jet build config updates (contains #53 update the descriptions of the GSD_SAR_v1 and RRFS_v0 tests)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NCAR/fv3atm
+	#url = https://github.com/NCAR/fv3atm
+	url = https://github.com/panll/fv3atm
 	branch = dtc/develop
 [submodule "NEMS"]
 	path = NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NCAR/fv3atm
-	url = https://github.com/panll/fv3atm
+	url = https://github.com/NCAR/fv3atm
 	branch = dtc/develop
 [submodule "NEMS"]
 	path = NEMS

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,7 @@ set -eu
 
 MYDIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 
-export COMPILER=${COMPILER:?"Please set COMPILER environment variable [gnu|intel]"}
-export CMAKE_Platform=linux.${COMPILER}
+export CMAKE_Platform=${CMAKE_Platform:?"Please set the CMAKE_Platform environment variable, e.g. [macosx.gnu|linux.gnu|linux.intel|hera.intel|...]"}
 export CMAKE_C_COMPILER=${CMAKE_C_COMPILER:-mpicc}
 export CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER:-mpicxx}
 export CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER:-mpif90}

--- a/cmake/configure_jet.intel.cmake
+++ b/cmake/configure_jet.intel.cmake
@@ -21,9 +21,11 @@ option(INLINE_POST "Enable inline post" OFF)
 
 include( cmake/${CMAKE_Fortran_COMPILER_ID}.cmake )
 
-message("AVX2 is   ENABLED on Jet (multi-tagret executable)")
+message("AVX2 is   ENABLED on Jet (multi-target executable)")
 string (REPLACE "-xHOST" "-axSSE4.2,AVX,CORE-AVX2" CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
 string (REPLACE "-xHOST" "-axSSE4.2,AVX,CORE-AVX2" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+# For CCPP
+option(SIMDMULTIARCH "Enable multi-target SIMD instruction sets" ON)
 
 string(REPLACE "-i_dynamic" "-shared-intel"
        CMAKE_SHARED_LIBRARY_LINK_Fortran_FLAGS

--- a/parm/ccpp_gsd_sar_v1.nml.IN
+++ b/parm/ccpp_gsd_sar_v1.nml.IN
@@ -175,8 +175,8 @@
        random_clds    = .false.
        trans_trac     = .true.
        cnvcld         = .false.
-       imfshalcnv     = 0
-       imfdeepcnv     = 0
+       imfshalcnv     = -1
+       imfdeepcnv     = -1
        cdmbgwd        = 3.5,0.25
        prslrd0        = 0.
        ivegsrc        = 1
@@ -193,7 +193,7 @@
        do_shum        = .F.
        do_skeb        = .F.
        do_sfcperts    = .F.
-       lsm            = 2
+       lsm            = 1
        lsoil          = 4
        iopt_dveg      = 2
        iopt_crs       = 1

--- a/tests/tests/fv3_ccpp_gsd_sar_v1
+++ b/tests/tests/fv3_ccpp_gsd_sar_v1
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-#  FV3 CCPP GSD SAR (GF CU + Thompson MP + MYNN PBL + RUC LSM) test
+#  FV3 CCPP GSD SAR ( Thompson MP + MYNN PBL + NOAH LSM) test
 #
 ###############################################################################
 

--- a/tests/tests/fv3_ccpp_rrfs_v0
+++ b/tests/tests/fv3_ccpp_rrfs_v0
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-#  FV3 CCPP GSD (GF CU + Thompson MP + MYNN PBL + NOAH LSM) test
+#  FV3 CCPP RRFS (Thompson MP + MYNN PBL + NOAHMP LSM) test
 #
 ###############################################################################
 
@@ -115,8 +115,8 @@ export INPUT_NML=ccpp_gsd.nml.IN
 
 export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
-export IMFSHALCNV=3
-export IMFDEEPCNV=3
+export IMFSHALCNV=-1
+export IMFDEEPCNV=-1
 export FHCYC=0
 export LSM=2
 export LSOIL_LSM=4


### PR DESCRIPTION
This PR:
- fixes a bug in the cmake build of CCPP for jet (use correct multiple SIMD instruction sets)
- update `build.sh` from UFS public release v1 branch
- contain's @panll's changes #53 "update the descriptions of the GSD_SAR_v1 and RRFS_v0 tests"

Associated PRs:
https://github.com/NCAR/fv3atm/pull/53
https://github.com/NCAR/ufs-weather-model/pull/55

For regression testing information, see below.