### PR TITLE
Add c96/regional/FA RT configuration for HAFS application

### DIFF
--- a/parm/ccpp_regional_FA.nml.IN
+++ b/parm/ccpp_regional_FA.nml.IN
@@ -1,0 +1,314 @@
+&amip_interp_nml
+       interp_oi_sst = .true.
+       use_ncep_sst = .true.
+       use_ncep_ice = .false.
+       no_anom_sst = .false.
+       data_set = 'reynolds_oi',
+       date_out_of_range = 'climo',
+/
+
+ &atmos_model_nml
+       blocksize = 32
+       chksum_debug = .false.
+       dycore_only = .false.
+       fdiag = @[FDIAG]
+       ccpp_suite = '@[CCPP_SUITE]'
+/
+
+&diag_manager_nml
+       prepend_date = .F.
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 2000200,
+       print_memory_usage = .false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   =  @[INPES],@[JNPES]
+       io_layout = 1,1
+       npx      = 211
+       npy      = 193
+       ntiles   = 1,
+       npz    = 64
+       !grid_type = -1
+       make_nh = @[MAKE_NH]
+       fv_debug = .F.
+       range_warn = .T.
+       reset_eta = .F.
+       n_sponge = 20
+       nudge_qv = .T.
+       tau = 3.0
+       rf_cutoff = 10.e2
+       d2_bg_k1 = 0.16
+       d2_bg_k2 = 0.02
+       kord_tm = -10
+       kord_mt =  10
+       kord_wz =  10
+       kord_tr =  10
+       hydrostatic = .F.
+       phys_hydrostatic = .F.
+       use_hydro_pressure = .F.
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = 2
+       n_split  = 6
+       nwat = 4
+       na_init = @[NA_INIT]
+       d_ext = 0.0
+       dnats = 1
+       fv_sg_adj = 450
+       d2_bg = 0.
+       nord =  2
+       dddmp = 0.1
+       d4_bg = 0.08
+       vtdm4 = 0.0
+       delt_max = 0.008
+       ke_bg = 0.
+       do_vort_damp = .T.
+       external_ic = @[EXTERNAL_IC]
+       external_eta = .T.
+       gfs_phil = .false.
+       nggps_ic = @[NGGPS_IC]
+       mountain = @[MOUNTAIN]
+       ncep_ic = .F.
+       d_con = 1.0
+       hord_mt =  6
+       hord_vt = -5
+       hord_tm = -5
+       hord_dp = -5
+       hord_tr = -8
+       adjust_dry_mass = .F.
+       consv_te = 0.
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = 6
+       warm_start = @[WARM_START]
+       no_dycore = .false.
+       z_tracer = .T.
+       read_increment = @[READ_INCREMENT]
+       res_latlon_dynamics = "fv3_increment.nc"
+
+       do_schmidt = .true.
+       target_lat = 35.5
+       target_lon = -97.5
+       stretch_fac = 1.5
+!!     nord_zs_filter = 4
+       n_zs_filter = 0
+       regional = .true.
+       bc_update_interval = 6
+       regional_bcs_from_gsi = .false.
+       write_restart_with_bcs = @[WRITE_RESTART_WITH_BCS]
+       nrows_blend = 0
+/
+
+ &external_ic_nml
+       filtered_terrain = .true.
+       levp = 65
+       gfs_dwinds = .true.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &gfs_physics_nml
+       fhzero         = 6.
+       ldiag3d        = .false.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 15
+       icloud         = @[ICLOUD]
+       iovr_lw        = @[IOVR_LW]
+       iovr_sw        = @[IOVR_SW]
+       spec_adv       = .true.
+       RHGRD            = 0.98
+       lradar         = @[LRADAR]
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .true.
+       shal_cnv       = .false.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = @[HYBEDMF]
+       satmedmf       = @[SATMEDMF]
+       lheatstrg      = @[LHEATSTRG]
+       hurr_pbl       = @[HURR_PBL]
+       moninq_fac     = @[MONINQ_FAC]
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .true.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 2.0, 0.25       ! NCEP default
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       lsm            = 1
+       iopt_dveg      = 2
+       iopt_crs       = 1
+       iopt_btr       = 1
+       iopt_run       = 1
+       iopt_sfc       = 1
+       iopt_frz       = 1
+       iopt_inf       = 1
+       iopt_rad       = 1
+       iopt_alb       = 2
+       iopt_snf       = 4
+       iopt_tbot      = 2
+       iopt_stc       = 1
+       debug          = .false.
+       oz_phys        = @[OZ_PHYS_OLD]
+       oz_phys_2015   = @[OZ_PHYS_NEW]
+       h2o_phys       = @[H2O_PHYS]
+       nstf_name      = 1,1,1,0,5
+       cplflx         = .F.
+       iau_delthrs    = 6
+       iaufhrs        = 30
+       iau_inc_files  = @[IAU_INC_FILES]
+       do_sppt        = @[DO_SPPT]
+       do_shum        = @[DO_SHUM]
+       do_skeb        = @[DO_SKEB]
+       do_sfcperts    = @[DO_SFCPERTS]
+/
+
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNGLAC   = "global_glacier.2x2.grb",
+       FNMXIC   = "global_maxice.2x2.grb",
+       FNTSFC   = "RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "global_snoclim.1.875.grb",
+       FNZORC   = "igbp"
+       FNALBC   = "global_snowfree_albedo.bosu.t126.384.190.rg.grb",
+       FNALBC2  = "global_albedo4.1x1.grb",
+       FNAISC   = "CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNTG3C   = "global_tg3clim.2.6x1.5.grb",
+       FNVEGC   = "global_vegfrac.0.144.decpercent.grb",
+       FNVETC   = "global_vegtype.igbp.t126.384.190.rg.grb",
+       FNSOTC   = "global_soiltype.statsgo.t126.384.190.rg.grb",
+       FNSMCC   = "global_soilmgldas.t126.384.190.grb",
+       FNMSKH   = "seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       FNVMNC   = "global_shdmin.0.144x0.144.grb",
+       FNVMXC   = "global_shdmax.0.144x0.144.grb",
+       FNSLPC   = "global_slope.1x1.grb",
+       FNABSC   = "global_mxsnoalb.uariz.t126.384.190.rg.grb",
+       LDEBUG   =.false.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+
+ &gfdl_cloud_microphysics_nml
+       sedi_transport = .false.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 180.
+       tau_v2l = 90.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 90.
+/
+
+&nam_stochy
+/
+
+&nam_sfcperts
+/
+
+&cires_ugwp_nml
+       knob_ugwp_solver  = 2
+       knob_ugwp_source  = 1,1,0,0
+       knob_ugwp_wvspec  = 1,25,25,25
+       knob_ugwp_azdir   = 2,4,4,4
+       knob_ugwp_stoch   = 0,0,0,0
+       knob_ugwp_effac   = 1,1,1,1
+       knob_ugwp_doaxyz  = 1
+       knob_ugwp_doheat  = 1
+       knob_ugwp_dokdis  = 1
+       knob_ugwp_ndx4lh  = 1
+       knob_ugwp_version = 0
+       launch_level      = 25
+/

--- a/tests/fv3_conf/ccpp_HAFS_v0_hwrf_run.IN
+++ b/tests/fv3_conf/ccpp_HAFS_v0_hwrf_run.IN
@@ -16,18 +16,21 @@ cp    @[RTPWD]/FV3_input_data/global_h2o_pltc.f77 ./global_h2oprdlos.f77
 cp    @[RTPWD]/FV3_input_data/*grb .
 cp    @[RTPWD]/FV3_input_data/*_table .
 cp    @[RTPWD]/FV3_input_data/*configure .
-cp    @[RTPWD]/FV3_input_data_hafs/GENPARM.TBL .
-cp    @[RTPWD]/FV3_input_data_hafs/SOILPARM.TBL .
-cp    @[RTPWD]/FV3_input_data_hafs/VEGPARM.TBL .
+#cp    @[RTPWD]/FV3_input_data_hafs/GENPARM.TBL .
+#cp    @[RTPWD]/FV3_input_data_hafs/SOILPARM.TBL .
+#cp    @[RTPWD]/FV3_input_data_hafs/VEGPARM.TBL .
+cp /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/hwrf-physics-20200618/INTEL/FV3_input_data_hafs/*TBL .
 
 # Copy diag table for HWRF RRTMG or GFS RRTMG
-if [ $IOVR_LW = 4 ] && [ $IOVR_SW = 4 ]; then
-    cp @[RTPWD]/FV3_input_data_hafs/diag_table_FA_HWRF diag_table
-else
-    cp @[RTPWD]/FV3_input_data_hafs/diag_table_FA diag_table
-fi
+#if [ $IOVR_LW = 4 ] && [ $IOVR_SW = 4 ]; then
+#    cp @[RTPWD]/FV3_input_data_hafs/diag_table_FA_HWRF diag_table
+#else
+#    cp @[RTPWD]/FV3_input_data_hafs/diag_table_FA diag_table
+#fi
 # Copy field table for Ferrier-Aligo MP
-cp @[RTPWD]/FV3_input_data_hafs/field_table_FA_nwat4 field_table
+#cp @[RTPWD]/FV3_input_data_hafs/field_table_FA_nwat4 field_table
+cp /home/Man.Zhang/field_table_FA_nwat4  field_table 
+cp /home/Man.Zhang/diag_table_HWRF diag_table
 
 cp @[RTPWD]/FV3_input_data/DETAMPNEW_DATA* .
 

--- a/tests/fv3_conf/ccpp_regional_control_FA_run.IN
+++ b/tests/fv3_conf/ccpp_regional_control_FA_run.IN
@@ -1,0 +1,42 @@
+rsync -arv @[RTPWD]/FV3_regional_input_data/. .
+rsync -arv @[RTPWD]/@[INPUT_DIR]/model_configure .
+
+rm -rf INPUT RESTART
+mkdir  INPUT RESTART
+
+rsync -arv @[RTPWD]/@[INPUT_DIR]/INPUT/. INPUT/.
+
+if [ $WARM_START = .T. ]; then
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.coupler.res             INPUT/coupler.res
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.fv_core.res.nc          INPUT/fv_core.res.nc
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.fv_core.res.tile1.nc    INPUT/fv_core.res.tile1.nc
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.fv_srf_wnd.res.tile1.nc INPUT/fv_srf_wnd.res.tile1.nc
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.fv_tracer.res.tile1.nc  INPUT/fv_tracer.res.tile1.nc
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.phy_data.nc             INPUT/phy_data.nc
+    cp ../fv3_ccpp_regional_control${RT_SUFFIX}/RESTART/20181015.120000.sfc_data.nc             INPUT/sfc_data.nc
+fi
+if [ $WRITE_RESTART_WITH_BCS = .true. ]; then
+    cp @[RTPWD]/fv3_regional_control/RESTART/fv_core.res.tile1_new.nc          RESTART/fv_core.res.tile1_new.nc
+    cp @[RTPWD]/fv3_regional_control/RESTART/fv_tracer.res.tile1_new.nc        RESTART/fv_tracer.res.tile1_new.nc
+fi
+
+
+if [ $OZ_PHYS_NEW = .T. ]; then
+  cp  @[RTPWD]/FV3_input_data/ozprdlos_2015_new_sbuvO3_tclm15_nuchem.f77 ./global_o3prdlos.f77
+elif [ $OZ_PHYS_OLD = .T. ]; then
+  cp  @[RTPWD]/FV3_input_data/INPUT/global_o3prdlos.f77 .
+fi
+if [ $H2O_PHYS = .T. ]; then
+  cp  @[RTPWD]/FV3_input_data/global_h2o_pltc.f77 ./global_h2oprdlos.f77
+fi
+
+cp    /home/Man.Zhang/DETAMPNEW_DATA.expanded_rain_LE .
+#cp    @[RTPWD]/FV3_input_data/*grb .
+cp    /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/hwrf-physics-20200618/INTEL/FV3_input_data_hafs/*.TBL .
+
+# Copy diag table for HWRF RRTMG or GFS RRTMG
+cp /home/Man.Zhang/diag_table_HWRF diag_table
+#cp /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/hwrf-physics-20200618/INTEL/FV3_input_data_hafs/field_table_FA_nwat4 field_table
+cp /home/Man.Zhang/field_table_FA_nwat4 field_table
+
+cp ${PATHRT}/../FV3/ccpp/suites/suite_${CCPP_SUITE}.xml suite_${CCPP_SUITE}.xml

--- a/tests/rt_hwrf_physics.conf
+++ b/tests/rt_hwrf_physics.conf
@@ -2,9 +2,9 @@
 # CCPP PROD tests                                                                                                                                                                     #
 #######################################################################################################################################################################################
 
-COMPILE | CCPP=Y SUITES=HAFS_v0_hwrf                                                                                                     | standard    |                | fv3         |
-
-RUN     | fv3_ccpp_HAFS_v0_hwrf                                                                                                          | standard    |                | fv3         |
+COMPILE | CCPP=Y SUITES=HAFS_v0_hwrf,FV3_HAFS_ferhires   DEBUG=Y                                                  | standard    |                | fv3         |
+RUN     | fv3_ccpp_HAFS_v0_hwrf                                                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_regional_control_FA                                                                            | standard    |                | fv3         |
 
 #######################################################################################################################################################################################
 # CCPP DEBUG tests                                                                                                                                                                     #

--- a/tests/tests/fv3_ccpp_regional_control_FA
+++ b/tests/tests/fv3_ccpp_regional_control_FA
@@ -1,0 +1,35 @@
+###############################################################################
+#
+#  FV3 CCPP regional control test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP regional control results with previous trunk version"
+
+export CNTL_DIR=fv3_regional_control
+
+export LIST_FILES="  atmos_4xdaily.nc \
+                     fv3_history2d.nc \
+                       fv3_history.nc \
+     RESTART/fv_core.res.tile1_new.nc \
+   RESTART/fv_tracer.res.tile1_new.nc"
+
+export_fv3
+
+export TASKS=24
+
+export RUN_SCRIPT=rt_fv3.sh
+export FV3_RUN=ccpp_regional_control_FA_run.IN
+
+export OZ_PHYS_OLD=.T.
+export OZ_PHYS_NEW=.F.
+export H2O_PHYS=.T.
+
+export CCPP_SUITE=FV3_HAFS_ferhires
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_regional_FA.nml.IN
+
+export FDIAG=3
+export INPES=4
+export JNPES=6
+export WRITE_RESTART_WITH_BCS=.F.


### PR DESCRIPTION
Add fv3_ccpp_regional_control_FA as c96/regional/FA RT configuration for HAFS application
associated PRs:
https://github.com/NCAR/GFDL_atmos_cubed_sphere/pull/17
https://github.com/NCAR/fv3atm/pull/62