### PR TITLE
feature/transition-to-capgen-1:  update SDF syntax and XML schema, remove DDT dependency in radiation physics, correct units

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NCAR/fv3atm
-	branch = feature/transition-to-capgen-1
+	#url = https://github.com/NCAR/fv3atm
+	#branch = feature/transition-to-capgen-1
+	url = https://github.com/climbfuji/fv3atm
+	branch = update_xsd_and_sdfs_and_ddt_gfs_rad_removal
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NCAR/fv3atm
-	#branch = feature/transition-to-capgen-1
-	url = https://github.com/climbfuji/fv3atm
-	branch = update_xsd_and_sdfs_and_ddt_gfs_rad_removal
+	url = https://github.com/NCAR/fv3atm
+	branch = feature/transition-to-capgen-1
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_cheyenne.gnu.log
+++ b/tests/RegressionTests_cheyenne.gnu.log
@@ -1,9 +1,9 @@
-Wed Sep 23 16:39:24 MDT 2020
+Tue Oct  6 14:37:19 MDT 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gfdlmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gfdlmp_prod
 Checking test 001 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -50,8 +50,8 @@ Checking test 001 fv3_ccpp_gfdlmp results ....
 Test 001 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gfs_v15p2_prod
 Checking test 002 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -118,8 +118,8 @@ Checking test 002 fv3_ccpp_gfs_v15p2 results ....
 Test 002 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gfs_v16beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gfs_v16beta_prod
 Checking test 003 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -186,8 +186,8 @@ Checking test 003 fv3_ccpp_gfs_v16beta results ....
 Test 003 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gfs_v16beta_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -254,8 +254,8 @@ Checking test 004 fv3_ccpp_gfs_v16beta_flake results ....
 Test 004 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gsd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gsd_prod
 Checking test 005 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -346,8 +346,8 @@ Checking test 005 fv3_ccpp_gsd results ....
 Test 005 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_thompson_prod
 Checking test 006 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -414,8 +414,8 @@ Checking test 006 fv3_ccpp_thompson results ....
 Test 006 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_thompson_no_aero_prod
 Checking test 007 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -482,8 +482,8 @@ Checking test 007 fv3_ccpp_thompson_no_aero results ....
 Test 007 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_rrfs_v1beta_prod
 Checking test 008 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -574,14 +574,14 @@ Checking test 008 fv3_ccpp_rrfs_v1beta results ....
 Test 008 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_control_debug_prod
 Checking test 009 fv3_ccpp_control_debug results ....
 Test 009 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gfs_v15p2_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gfs_v15p2_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gfs_v15p2_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gfs_v15p2_debug_prod
 Checking test 010 fv3_ccpp_gfs_v15p2_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -648,8 +648,8 @@ Checking test 010 fv3_ccpp_gfs_v15p2_debug results ....
 Test 010 fv3_ccpp_gfs_v15p2_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_gfs_v16beta_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_gfs_v16beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 011 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -716,8 +716,8 @@ Checking test 011 fv3_ccpp_gfs_v16beta_debug results ....
 Test 011 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/GNU/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_68881/fv3_ccpp_multigases_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/GNU/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_36387/fv3_ccpp_multigases_prod
 Checking test 012 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -791,5 +791,5 @@ Test 012 fv3_ccpp_multigases PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Sep 23 17:03:55 MDT 2020
-Elapsed time: 00h:24m:32s. Have a nice day!
+Tue Oct  6 14:59:44 MDT 2020
+Elapsed time: 00h:22m:25s. Have a nice day!

--- a/tests/RegressionTests_cheyenne.intel.log
+++ b/tests/RegressionTests_cheyenne.intel.log
@@ -1,9 +1,9 @@
-Wed Sep 23 20:42:23 MDT 2020
+Tue Oct  6 20:36:45 MDT 2020
 Start Regression test
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_control_prod
 Checking test 001 fv3_ccpp_control results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -70,8 +70,8 @@ Checking test 001 fv3_ccpp_control results ....
 Test 001 fv3_ccpp_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_decomp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_decomp_prod
 Checking test 002 fv3_ccpp_decomp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -138,8 +138,8 @@ Checking test 002 fv3_ccpp_decomp results ....
 Test 002 fv3_ccpp_decomp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_2threads_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_2threads_prod
 Checking test 003 fv3_ccpp_2threads results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -206,8 +206,8 @@ Checking test 003 fv3_ccpp_2threads results ....
 Test 003 fv3_ccpp_2threads PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_restart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_restart_prod
 Checking test 004 fv3_ccpp_restart results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -274,8 +274,8 @@ Checking test 004 fv3_ccpp_restart results ....
 Test 004 fv3_ccpp_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_read_inc_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_read_inc_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_read_inc_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_read_inc_prod
 Checking test 005 fv3_ccpp_read_inc results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -342,8 +342,8 @@ Checking test 005 fv3_ccpp_read_inc results ....
 Test 005 fv3_ccpp_read_inc PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_wrtGauss_netcdf_esmf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_wrtGauss_netcdf_esmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_wrtGauss_netcdf_esmf_prod
 Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -390,8 +390,8 @@ Checking test 006 fv3_ccpp_wrtGauss_netcdf_esmf results ....
 Test 006 fv3_ccpp_wrtGauss_netcdf_esmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_wrtGauss_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_wrtGauss_netcdf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_wrtGauss_netcdf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_wrtGauss_netcdf_prod
 Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -438,8 +438,8 @@ Checking test 007 fv3_ccpp_wrtGauss_netcdf results ....
 Test 007 fv3_ccpp_wrtGauss_netcdf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_wrtGlatlon_netcdf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_wrtGlatlon_netcdf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_wrtGlatlon_netcdf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_wrtGlatlon_netcdf_prod
 Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -486,8 +486,8 @@ Checking test 008 fv3_ccpp_wrtGlatlon_netcdf results ....
 Test 008 fv3_ccpp_wrtGlatlon_netcdf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_wrtGauss_nemsio_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_wrtGauss_nemsio_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_wrtGauss_nemsio_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_wrtGauss_nemsio_prod
 Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -534,8 +534,8 @@ Checking test 009 fv3_ccpp_wrtGauss_nemsio results ....
 Test 009 fv3_ccpp_wrtGauss_nemsio PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_wrtGauss_nemsio_c192_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_wrtGauss_nemsio_c192_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_wrtGauss_nemsio_c192_prod
 Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -582,8 +582,8 @@ Checking test 010 fv3_ccpp_wrtGauss_nemsio_c192 results ....
 Test 010 fv3_ccpp_wrtGauss_nemsio_c192 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_stochy_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_stochy_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_stochy_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_stochy_prod
 Checking test 011 fv3_ccpp_stochy results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -650,8 +650,8 @@ Checking test 011 fv3_ccpp_stochy results ....
 Test 011 fv3_ccpp_stochy PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_iau_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_iau_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_iau_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_iau_prod
 Checking test 012 fv3_ccpp_iau results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -718,8 +718,8 @@ Checking test 012 fv3_ccpp_iau results ....
 Test 012 fv3_ccpp_iau PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_ca_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_ca_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_ca_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_ca_prod
 Checking test 013 fv3_ccpp_ca results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -786,8 +786,8 @@ Checking test 013 fv3_ccpp_ca results ....
 Test 013 fv3_ccpp_ca PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_lheatstrg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_lheatstrg_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_lheatstrg_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_lheatstrg_prod
 Checking test 014 fv3_ccpp_lheatstrg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -834,8 +834,8 @@ Checking test 014 fv3_ccpp_lheatstrg results ....
 Test 014 fv3_ccpp_lheatstrg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_multigases_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_multigases_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_multigases_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_multigases_prod
 Checking test 015 fv3_ccpp_multigases results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -908,8 +908,8 @@ Checking test 015 fv3_ccpp_multigases results ....
 Test 015 fv3_ccpp_multigases PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_control_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_control_32bit_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_control_32bit_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_control_32bit_prod
 Checking test 016 fv3_ccpp_control_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -976,8 +976,8 @@ Checking test 016 fv3_ccpp_control_32bit results ....
 Test 016 fv3_ccpp_control_32bit PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_stretched_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_stretched_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_stretched_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_stretched_prod
 Checking test 017 fv3_ccpp_stretched results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1032,8 +1032,8 @@ Checking test 017 fv3_ccpp_stretched results ....
 Test 017 fv3_ccpp_stretched PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_stretched_nest_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_stretched_nest_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_stretched_nest_prod
 Checking test 018 fv3_ccpp_stretched_nest results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1099,8 +1099,8 @@ Checking test 018 fv3_ccpp_stretched_nest results ....
 Test 018 fv3_ccpp_stretched_nest PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_regional_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_regional_control_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_regional_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_regional_control_prod
 Checking test 019 fv3_ccpp_regional_control results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1110,8 +1110,8 @@ Checking test 019 fv3_ccpp_regional_control results ....
 Test 019 fv3_ccpp_regional_control PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_regional_restart_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_regional_restart_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_regional_restart_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_regional_restart_prod
 Checking test 020 fv3_ccpp_regional_restart results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1119,8 +1119,8 @@ Checking test 020 fv3_ccpp_regional_restart results ....
 Test 020 fv3_ccpp_regional_restart PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_regional_quilt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_regional_quilt_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_regional_quilt_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_regional_quilt_prod
 Checking test 021 fv3_ccpp_regional_quilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing dynf000.nc .........OK
@@ -1130,20 +1130,20 @@ Checking test 021 fv3_ccpp_regional_quilt results ....
 Test 021 fv3_ccpp_regional_quilt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_control_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_control_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_control_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_control_debug_prod
 Checking test 022 fv3_ccpp_control_debug results ....
 Test 022 fv3_ccpp_control_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_stretched_nest_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_stretched_nest_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_stretched_nest_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_stretched_nest_debug_prod
 Checking test 023 fv3_ccpp_stretched_nest_debug results ....
 Test 023 fv3_ccpp_stretched_nest_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfdlmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfdlmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfdlmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfdlmp_prod
 Checking test 024 fv3_ccpp_gfdlmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1190,8 +1190,8 @@ Checking test 024 fv3_ccpp_gfdlmp results ....
 Test 024 fv3_ccpp_gfdlmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfdlmprad_gwd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfdlmprad_gwd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfdlmprad_gwd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfdlmprad_gwd_prod
 Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1238,8 +1238,8 @@ Checking test 025 fv3_ccpp_gfdlmprad_gwd results ....
 Test 025 fv3_ccpp_gfdlmprad_gwd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfdlmprad_noahmp_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfdlmprad_noahmp_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfdlmprad_noahmp_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfdlmprad_noahmp_prod
 Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1286,8 +1286,8 @@ Checking test 026 fv3_ccpp_gfdlmprad_noahmp results ....
 Test 026 fv3_ccpp_gfdlmprad_noahmp PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfdlmp_hwrfsas_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfdlmp_hwrfsas_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfdlmp_hwrfsas_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfdlmp_hwrfsas_prod
 Checking test 027 fv3_ccpp_gfdlmp_hwrfsas results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1334,8 +1334,8 @@ Checking test 027 fv3_ccpp_gfdlmp_hwrfsas results ....
 Test 027 fv3_ccpp_gfdlmp_hwrfsas PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_csawmg_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_csawmg_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_csawmg_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_csawmg_prod
 Checking test 028 fv3_ccpp_csawmg results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1382,8 +1382,8 @@ Checking test 028 fv3_ccpp_csawmg results ....
 Test 028 fv3_ccpp_csawmg PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_satmedmf_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_satmedmf_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_satmedmf_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_satmedmf_prod
 Checking test 029 fv3_ccpp_satmedmf results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1430,8 +1430,8 @@ Checking test 029 fv3_ccpp_satmedmf results ....
 Test 029 fv3_ccpp_satmedmf PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_satmedmfq_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_satmedmfq_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_satmedmfq_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_satmedmfq_prod
 Checking test 030 fv3_ccpp_satmedmfq results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1478,8 +1478,8 @@ Checking test 030 fv3_ccpp_satmedmfq results ....
 Test 030 fv3_ccpp_satmedmfq PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfdlmp_32bit_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfdlmp_32bit_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfdlmp_32bit_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfdlmp_32bit_prod
 Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1526,8 +1526,8 @@ Checking test 031 fv3_ccpp_gfdlmp_32bit results ....
 Test 031 fv3_ccpp_gfdlmp_32bit PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfdlmprad_32bit_post_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfdlmprad_32bit_post_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfdlmprad_32bit_post_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfdlmprad_32bit_post_prod
 Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1578,8 +1578,8 @@ Checking test 032 fv3_ccpp_gfdlmprad_32bit_post results ....
 Test 032 fv3_ccpp_gfdlmprad_32bit_post PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_cpt_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_cpt_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_cpt_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_cpt_prod
 Checking test 033 fv3_ccpp_cpt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1632,8 +1632,8 @@ Checking test 033 fv3_ccpp_cpt results ....
 Test 033 fv3_ccpp_cpt PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gsd_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gsd_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gsd_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gsd_prod
 Checking test 034 fv3_ccpp_gsd results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1724,8 +1724,8 @@ Checking test 034 fv3_ccpp_gsd results ....
 Test 034 fv3_ccpp_gsd PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_thompson_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_thompson_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_thompson_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_thompson_prod
 Checking test 035 fv3_ccpp_thompson results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1792,8 +1792,8 @@ Checking test 035 fv3_ccpp_thompson results ....
 Test 035 fv3_ccpp_thompson PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_thompson_no_aero_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_thompson_no_aero_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_thompson_no_aero_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_thompson_no_aero_prod
 Checking test 036 fv3_ccpp_thompson_no_aero results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1860,8 +1860,8 @@ Checking test 036 fv3_ccpp_thompson_no_aero results ....
 Test 036 fv3_ccpp_thompson_no_aero PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_rrfs_v1beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_rrfs_v1beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_rrfs_v1beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_rrfs_v1beta_prod
 Checking test 037 fv3_ccpp_rrfs_v1beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -1952,8 +1952,8 @@ Checking test 037 fv3_ccpp_rrfs_v1beta results ....
 Test 037 fv3_ccpp_rrfs_v1beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfs_v15p2_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfs_v15p2_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfs_v15p2_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfs_v15p2_prod
 Checking test 038 fv3_ccpp_gfs_v15p2 results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2020,8 +2020,8 @@ Checking test 038 fv3_ccpp_gfs_v15p2 results ....
 Test 038 fv3_ccpp_gfs_v15p2 PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfs_v16beta_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfs_v16beta_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfs_v16beta_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfs_v16beta_prod
 Checking test 039 fv3_ccpp_gfs_v16beta results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2088,8 +2088,8 @@ Checking test 039 fv3_ccpp_gfs_v16beta results ....
 Test 039 fv3_ccpp_gfs_v16beta PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gocart_clm_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gocart_clm_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gocart_clm_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gocart_clm_prod
 Checking test 040 fv3_ccpp_gocart_clm results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2136,8 +2136,8 @@ Checking test 040 fv3_ccpp_gocart_clm results ....
 Test 040 fv3_ccpp_gocart_clm PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfs_v16beta_flake_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfs_v16beta_flake_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfs_v16beta_flake_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfs_v16beta_flake_prod
 Checking test 041 fv3_ccpp_gfs_v16beta_flake results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2204,8 +2204,8 @@ Checking test 041 fv3_ccpp_gfs_v16beta_flake results ....
 Test 041 fv3_ccpp_gfs_v16beta_flake PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gfs_v16beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gfs_v16beta_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gfs_v16beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gfs_v16beta_debug_prod
 Checking test 042 fv3_ccpp_gfs_v16beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2272,8 +2272,8 @@ Checking test 042 fv3_ccpp_gfs_v16beta_debug results ....
 Test 042 fv3_ccpp_gfs_v16beta_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gsd_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gsd_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gsd_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gsd_debug_prod
 Checking test 043 fv3_ccpp_gsd_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2340,8 +2340,8 @@ Checking test 043 fv3_ccpp_gsd_debug results ....
 Test 043 fv3_ccpp_gsd_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_gsd_diag3d_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_gsd_diag3d_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_gsd_diag3d_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_gsd_diag3d_debug_prod
 Checking test 044 fv3_ccpp_gsd_diag3d_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2408,8 +2408,8 @@ Checking test 044 fv3_ccpp_gsd_diag3d_debug results ....
 Test 044 fv3_ccpp_gsd_diag3d_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_thompson_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_thompson_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_thompson_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_thompson_debug_prod
 Checking test 045 fv3_ccpp_thompson_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2476,8 +2476,8 @@ Checking test 045 fv3_ccpp_thompson_debug results ....
 Test 045 fv3_ccpp_thompson_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_thompson_no_aero_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_thompson_no_aero_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_thompson_no_aero_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_thompson_no_aero_debug_prod
 Checking test 046 fv3_ccpp_thompson_no_aero_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2544,8 +2544,8 @@ Checking test 046 fv3_ccpp_thompson_no_aero_debug results ....
 Test 046 fv3_ccpp_thompson_no_aero_debug PASS
 
 
-baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200923/INTEL/fv3_rrfs_v1beta_debug_ccpp
-working dir  = /glade/scratch/heinzell/FV3_RT/rt_23962/fv3_ccpp_rrfs_v1beta_debug_prod
+baseline dir = /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/develop-20200929/INTEL/fv3_rrfs_v1beta_debug_ccpp
+working dir  = /glade/scratch/heinzell/FV3_RT/rt_11687/fv3_ccpp_rrfs_v1beta_debug_prod
 Checking test 047 fv3_ccpp_rrfs_v1beta_debug results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -2613,5 +2613,5 @@ Test 047 fv3_ccpp_rrfs_v1beta_debug PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Sep 24 00:22:25 MDT 2020
-Elapsed time: 03h:40m:02s. Have a nice day!
+Tue Oct  6 21:06:47 MDT 2020
+Elapsed time: 00h:30m:02s. Have a nice day!


### PR DESCRIPTION
## Description

This PR only updates the submodule pointers for fv3atm, ccpp-framework and ccpp-physics for the changes described in the associated PRs:

- support for removal of GFS DDTs from CCPP radiation physics from @grantfirl 
- correct metadata name/unit/dimensions from @mzhangw
- update XML schema and syntax for all suite definition files; all SDFs validate against suite.xsd using xmllint

## Testing

Regression tests against existing baselines passed on the following platforms:

- cheyenne.gnu
- cheyenne.intel

This is sufficient for the purpose of updating feature/transition-to-capgen-1. Full regression tests on all tier-1 platforms will be run when feature/transition-to-capgen-1 is sent to the authoritative repositories.

Output from xmllint, showing that all suites validate against the updated/simplified `suites.xsd` schema: 

[xmllint_output_20201005T1700.txt](https://github.com/NCAR/ufs-weather-model/files/5340965/xmllint_output_20201005T1700.txt)


## Dependencies

https://github.com/NCAR/ccpp-physics/pull/506
https://github.com/NCAR/ccpp-framework/pull/327
https://github.com/NCAR/fv3atm/pull/64
https://github.com/NCAR/ufs-weather-model/pull/65